### PR TITLE
Fix for pulp bug "incorrect length of data produced"

### DIFF
--- a/build-gems
+++ b/build-gems
@@ -44,7 +44,7 @@ do
     echo "$prefix Building $basename version $version"
     extra_args="-v $version $extra_args"
   fi
-  extra_args="--gem-bin-path $GEM_BIN_PATH --prefix $GEM_PREFIX $extra_args"
+  extra_args="--gem-bin-path $GEM_BIN_PATH -- vendor Inuits --prefix $GEM_PREFIX $extra_args"
   extra_args="-d 'ruby(rubygems)' -d 'ruby(abi) = 1.8'  $extra_args"
 
   if [ "$arch" == 'arch' ]; then

--- a/build-gems
+++ b/build-gems
@@ -44,7 +44,7 @@ do
     echo "$prefix Building $basename version $version"
     extra_args="-v $version $extra_args"
   fi
-  extra_args="--gem-bin-path $GEM_BIN_PATH -- vendor Inuits --prefix $GEM_PREFIX $extra_args"
+  extra_args="--gem-bin-path $GEM_BIN_PATH --vendor Inuits --prefix $GEM_PREFIX $extra_args"
   extra_args="-d 'ruby(rubygems)' -d 'ruby(abi) = 1.8'  $extra_args"
 
   if [ "$arch" == 'arch' ]; then


### PR DESCRIPTION
Since we're hitting a pulp bug which will be fixed in 2.6 (which isnt out yet), I suggest the following fix which changes the vendor names from the gem packages (which can contain non-ascii characters) to something we know does not contain ascii characters
